### PR TITLE
LineItem type changes

### DIFF
--- a/lib/client.go
+++ b/lib/client.go
@@ -85,7 +85,7 @@ func (c *Client) GetProjectReport(extProjectID string) (*ProjectReportResponse, 
 }
 
 // AddLineItem ...
-func (c *Client) AddLineItem(extProjectID string, lineItem *LineItemCriteria) (*LineItemResponse, error) {
+func (c *Client) AddLineItem(extProjectID string, lineItem *CreateLineItemCriteria) (*LineItemResponse, error) {
 	res := &LineItemResponse{}
 	path := fmt.Sprintf("/projects/%s/lineItems", extProjectID)
 	err := c.requestAndParseResponse("POST", path, lineItem, res)
@@ -93,7 +93,7 @@ func (c *Client) AddLineItem(extProjectID string, lineItem *LineItemCriteria) (*
 }
 
 // UpdateLineItem ...
-func (c *Client) UpdateLineItem(extProjectID, extLineItemID string, lineItem *LineItemCriteria) (*LineItemResponse, error) {
+func (c *Client) UpdateLineItem(extProjectID, extLineItemID string, lineItem *UpdateLineItemCriteria) (*LineItemResponse, error) {
 	res := &LineItemResponse{}
 	path := fmt.Sprintf("/projects/%s/lineItems/%s", extProjectID, extLineItemID)
 	err := c.requestAndParseResponse("POST", path, lineItem, res)

--- a/lib/client.go
+++ b/lib/client.go
@@ -29,14 +29,14 @@ type Client struct {
 }
 
 // CreateProject ...
-func (c *Client) CreateProject(project *CreateUpdateProjectCriteria) (*ProjectResponse, error) {
+func (c *Client) CreateProject(project *CreateProjectCriteria) (*ProjectResponse, error) {
 	res := &ProjectResponse{}
 	err := c.requestAndParseResponse("POST", "/projects", project, res)
 	return res, err
 }
 
 // UpdateProject ...
-func (c *Client) UpdateProject(project *CreateUpdateProjectCriteria) (*ProjectResponse, error) {
+func (c *Client) UpdateProject(project *UpdateProjectCriteria) (*ProjectResponse, error) {
 	res := &ProjectResponse{}
 	path := fmt.Sprintf("/projects/%s", project.ExtProjectID)
 	err := c.requestAndParseResponse("POST", path, project, res)

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -70,7 +70,7 @@ func TestClientFunctions(t *testing.T) {
 	client.Auth = getAuth()
 
 	client.CreateProject(nil)
-	client.UpdateProject(&samplify.CreateUpdateProjectCriteria{ExtProjectID: "update-test"})
+	client.UpdateProject(&samplify.UpdateProjectCriteria{ExtProjectID: "update-test"})
 	client.BuyProject("buy-test", nil)
 	client.CloseProject("close-test")
 	client.GetAllProjects(nil)

--- a/lib/line_item.go
+++ b/lib/line_item.go
@@ -39,8 +39,8 @@ type QuotaGroup struct {
 
 // Quota ...
 type Quota struct {
-	AttributeID string         `json:"attributeId"`
-	Options     []*QuotaOption `json:"options"`
+	AttributeID string          `json:"attributeId"`
+	Options     *[]*QuotaOption `json:"options"`
 }
 
 // QuotaOption ...
@@ -84,8 +84,8 @@ type LineItem struct {
 	EndLinks            *EndLinks  `json:"endLinks"`
 }
 
-// LineItemCriteria has the fields to create or update a LineItem
-type LineItemCriteria struct {
+// CreateLineItemCriteria has the fields to create or update a LineItem
+type CreateLineItemCriteria struct {
 	ExtLineItemID       string     `json:"extLineItemId"`
 	Title               string     `json:"title"`
 	CountryISOCode      string     `json:"countryISOCode"`
@@ -96,6 +96,21 @@ type LineItemCriteria struct {
 	DaysInField         int64      `json:"daysInField"`
 	LengthOfInterview   int64      `json:"lengthOfInterview"`
 	RequiredCompletes   int64      `json:"requiredCompletes"`
+	QuotaPlan           *QuotaPlan `json:"quotaPlan"`
+}
+
+// UpdateLineItemCriteria has the fields to create or update a LineItem
+type UpdateLineItemCriteria struct {
+	ExtLineItemID       string     `json:"extLineItemId"`
+	Title               *string    `json:"title"`
+	CountryISOCode      *string    `json:"countryISOCode"`
+	LanguageISOCode     *string    `json:"languageISOCode"`
+	SurveyURL           *string    `json:"surveyURL,omitempty"`
+	SurveyTestURL       *string    `json:"surveyTestURL,omitempty"`
+	IndicativeIncidence *float64   `json:"indicativeIncidence"`
+	DaysInField         *int64     `json:"daysInField"`
+	LengthOfInterview   *int64     `json:"lengthOfInterview"`
+	RequiredCompletes   *int64     `json:"requiredCompletes"`
 	QuotaPlan           *QuotaPlan `json:"quotaPlan"`
 }
 

--- a/lib/line_item.go
+++ b/lib/line_item.go
@@ -90,8 +90,8 @@ type LineItemCriteria struct {
 	Title               string     `json:"title"`
 	CountryISOCode      string     `json:"countryISOCode"`
 	LanguageISOCode     string     `json:"languageISOCode"`
-	SurveyURL           *string    `json:"surveyURL"`
-	SurveyTestURL       *string    `json:"surveyTestURL"`
+	SurveyURL           *string    `json:"surveyURL,omitempty"`
+	SurveyTestURL       *string    `json:"surveyTestURL,omitempty"`
 	IndicativeIncidence float64    `json:"indicativeIncidence"`
 	DaysInField         int64      `json:"daysInField"`
 	LengthOfInterview   int64      `json:"lengthOfInterview"`

--- a/lib/line_item.go
+++ b/lib/line_item.go
@@ -90,8 +90,8 @@ type LineItemCriteria struct {
 	Title               string     `json:"title"`
 	CountryISOCode      string     `json:"countryISOCode"`
 	LanguageISOCode     string     `json:"languageISOCode"`
-	SurveyURL           string     `json:"surveyURL"`
-	SurveyTestURL       string     `json:"surveyTestURL"`
+	SurveyURL           *string    `json:"surveyURL"`
+	SurveyTestURL       *string    `json:"surveyTestURL"`
 	IndicativeIncidence float64    `json:"indicativeIncidence"`
 	DaysInField         int64      `json:"daysInField"`
 	LengthOfInterview   int64      `json:"lengthOfInterview"`

--- a/lib/line_item.go
+++ b/lib/line_item.go
@@ -59,10 +59,13 @@ type EndLinks struct {
 // LineItemHeader ...
 type LineItemHeader struct {
 	Model
-	ExtLineItemID string      `json:"extLineItemId"`
-	State         State       `json:"state"`
-	StateReason   string      `json:"stateReason"`
-	LaunchedAt    *CustomTime `json:"launchedAt"`
+	Title           string      `json:"title"`
+	CountryISOCode  string      `json:"countryISOCode"`
+	LanguageISOCode string      `json:"languageISOCode"`
+	ExtLineItemID   string      `json:"extLineItemId"`
+	State           State       `json:"state"`
+	StateReason     string      `json:"stateReason"`
+	LaunchedAt      *CustomTime `json:"launchedAt"`
 }
 
 // LineItem ...

--- a/lib/project.go
+++ b/lib/project.go
@@ -64,13 +64,13 @@ type Project struct {
 
 // CreateUpdateProjectCriteria has the fields to create or update a project
 type CreateUpdateProjectCriteria struct {
-	ExtProjectID       string              `json:"extProjectId"`
-	Title              string              `json:"title"`
-	NotificationEmails []string            `json:"notificationEmails"`
-	Devices            []DeviceType        `json:"devices"`
-	Category           *Category           `json:"category"`
-	LineItems          []*LineItemCriteria `json:"lineItems"`
-	Exclusions         *Exclusions         `json:"exclusions"`
+	ExtProjectID       string               `json:"extProjectId"`
+	Title              *string              `json:"title"`
+	NotificationEmails *[]string            `json:"notificationEmails"`
+	Devices            *[]DeviceType        `json:"devices"`
+	Category           *Category            `json:"category"`
+	LineItems          *[]*LineItemCriteria `json:"lineItems"`
+	Exclusions         *Exclusions          `json:"exclusions"`
 }
 
 // BuyProjectCriteria ...

--- a/lib/project.go
+++ b/lib/project.go
@@ -64,25 +64,25 @@ type Project struct {
 
 // CreateProjectCriteria holds fields to create a project.
 type CreateProjectCriteria struct {
-	ExtProjectID       string              `json:"extProjectId"`
-	Title              string              `json:"title"`
-	NotificationEmails []string            `json:"notificationEmails"`
-	Devices            []DeviceType        `json:"devices"`
-	Category           *Category           `json:"category"`
-	LineItems          []*LineItemCriteria `json:"lineItems"`
-	Exclusions         *Exclusions         `json:"exclusions"`
+	ExtProjectID       string                    `json:"extProjectId"`
+	Title              string                    `json:"title"`
+	NotificationEmails []string                  `json:"notificationEmails"`
+	Devices            []DeviceType              `json:"devices"`
+	Category           *Category                 `json:"category"`
+	LineItems          []*CreateLineItemCriteria `json:"lineItems"`
+	Exclusions         *Exclusions               `json:"exclusions"`
 }
 
 // UpdateProjectCriteria has the fields to update a project.
 // Excluding ExtProjectID, its fields are optional.
 type UpdateProjectCriteria struct {
-	ExtProjectID       string               `json:"extProjectId"`
-	Title              *string              `json:"title,omitempty"`
-	NotificationEmails *[]string            `json:"notificationEmails,omitempty"`
-	Devices            *[]DeviceType        `json:"devices,omitempty"`
-	Category           *Category            `json:"category,omitempty"`
-	LineItems          *[]*LineItemCriteria `json:"lineItems,omitempty"`
-	Exclusions         *Exclusions          `json:"exclusions,omitempty"`
+	ExtProjectID       string                     `json:"extProjectId"`
+	Title              *string                    `json:"title,omitempty"`
+	NotificationEmails *[]string                  `json:"notificationEmails,omitempty"`
+	Devices            *[]DeviceType              `json:"devices,omitempty"`
+	Category           *Category                  `json:"category,omitempty"`
+	LineItems          *[]*CreateLineItemCriteria `json:"lineItems,omitempty"`
+	Exclusions         *Exclusions                `json:"exclusions,omitempty"`
 }
 
 // BuyProjectCriteria ...

--- a/lib/project.go
+++ b/lib/project.go
@@ -62,15 +62,27 @@ type Project struct {
 	Exclusions         *Exclusions  `json:"exclusions"`
 }
 
-// CreateUpdateProjectCriteria has the fields to create or update a project
-type CreateUpdateProjectCriteria struct {
+// CreateProjectCriteria holds fields to create a project.
+type CreateProjectCriteria struct {
+	ExtProjectID       string              `json:"extProjectId"`
+	Title              string              `json:"title"`
+	NotificationEmails []string            `json:"notificationEmails"`
+	Devices            []DeviceType        `json:"devices"`
+	Category           *Category           `json:"category"`
+	LineItems          []*LineItemCriteria `json:"lineItems"`
+	Exclusions         *Exclusions         `json:"exclusions"`
+}
+
+// UpdateProjectCriteria has the fields to update a project.
+// Excluding ExtProjectID, its fields are optional.
+type UpdateProjectCriteria struct {
 	ExtProjectID       string               `json:"extProjectId"`
-	Title              *string              `json:"title"`
-	NotificationEmails *[]string            `json:"notificationEmails"`
-	Devices            *[]DeviceType        `json:"devices"`
-	Category           *Category            `json:"category"`
-	LineItems          *[]*LineItemCriteria `json:"lineItems"`
-	Exclusions         *Exclusions          `json:"exclusions"`
+	Title              *string              `json:"title,omitempty"`
+	NotificationEmails *[]string            `json:"notificationEmails,omitempty"`
+	Devices            *[]DeviceType        `json:"devices,omitempty"`
+	Category           *Category            `json:"category,omitempty"`
+	LineItems          *[]*LineItemCriteria `json:"lineItems,omitempty"`
+	Exclusions         *Exclusions          `json:"exclusions,omitempty"`
 }
 
 // BuyProjectCriteria ...

--- a/lib/response.go
+++ b/lib/response.go
@@ -59,14 +59,9 @@ type UpdateLineItemStateResponse struct {
 
 // GetAllLineItemsResponse ...
 type GetAllLineItemsResponse struct {
-	List []*struct {
-		LineItemHeader
-		Title           string `json:"title"`
-		CountryISOCode  string `json:"countryISOCode"`
-		LanguageISOCode string `json:"languageISOCode"`
-	} `json:"data"`
-	ResponseStatus ResponseStatus `json:"status"`
-	Meta           Meta           `json:"meta"`
+	List           []*LineItemHeader `json:"data"`
+	ResponseStatus ResponseStatus    `json:"status"`
+	Meta           Meta              `json:"meta"`
 }
 
 // GetFeasibilityResponse ...


### PR DESCRIPTION
This PR changes some types around Line Items, including:

- Add fields to LineItemHeader to match the type returned by [the API](https://researchnow.github.io/samplifyapi-docs/#get-all-line-items)
- Change LineItemCriteria to accept pointers for the optional fields SurveyURL and SurveyTestURL