### PR TITLE
Feature time based project exclusions

### DIFF
--- a/lib/exclusions.go
+++ b/lib/exclusions.go
@@ -6,7 +6,6 @@ import (
 	"time"
 )
 
-
 // ExclusionType ...
 type ExclusionType string
 
@@ -21,12 +20,12 @@ var ExclusionTypes = []ExclusionType{
 
 // ExclusionType values
 const (
-	ExclusionTypeProject 		ExclusionType = "PROJECT"
-	ExclusionTypeTag 			ExclusionType = "TAG"
-	ExclusionTypeThisMonth     	ExclusionType = "THIS_MONTH"
-	ExclusionTypeLastMonth     	ExclusionType = "LAST_MONTH"
+	ExclusionTypeProject        ExclusionType = "PROJECT"
+	ExclusionTypeTag            ExclusionType = "TAG"
+	ExclusionTypeThisMonth      ExclusionType = "THIS_MONTH"
+	ExclusionTypeLastMonth      ExclusionType = "LAST_MONTH"
 	ExclusionTypeLastThreeMonth ExclusionType = "LAST_THREE_MONTHS"
-	ExclusionTypeCustom     	ExclusionType = "CUSTOM"
+	ExclusionTypeCustom         ExclusionType = "CUSTOM_TIME_PERIOD"
 )
 
 func (p ExclusionType) String() string {
@@ -35,13 +34,13 @@ func (p ExclusionType) String() string {
 
 // Exclusions ... Project's exclusions
 type Exclusions struct {
-	Type ExclusionType `json:"type" valid:"ExclusionType"`
-	List []string      `json:"list"`
-	StartDate *string  `json:"startDate"`
-	EndDate   *string  `json:"endDate"`
+	Type      ExclusionType `json:"type" valid:"ExclusionType"`
+	List      []string      `json:"list"`
+	StartDate *string       `json:"startDate"`
+	EndDate   *string       `json:"endDate"`
 }
 
-func (e *Exclusions) ComputeDates(){
+func (e *Exclusions) ComputeDates() {
 	now := time.Now()
 	current := now.Format(TimeLayout)
 	switch e.Type {
@@ -81,7 +80,7 @@ func EndOfMonth(t time.Time) time.Time {
 func (e *Exclusions) ValidateDates() error {
 	switch e.Type {
 	case ExclusionTypeCustom:
-		if e.StartDate == nil{
+		if e.StartDate == nil {
 			return errors.New("exclusion start date cannot be empty")
 		}
 		if e.EndDate == nil {
@@ -92,14 +91,15 @@ func (e *Exclusions) ValidateDates() error {
 		if err != nil{
 			return err
 		}
-		if start.After(end) || end.Before(start){
+
+		if start.After(end) || end.Before(start) {
 			return fmt.Errorf("invalid date ranges: %s and %s", *e.StartDate, *e.EndDate)
 		}
 	}
 	return nil
 }
 
-func (e *Exclusions) AddProjects(extProjectIDs []string) error{
+func (e *Exclusions) AddProjects(extProjectIDs []string) error {
 	m := make(map[string]bool)
 
 	for _, item := range e.List {

--- a/lib/exclusions.go
+++ b/lib/exclusions.go
@@ -1,0 +1,93 @@
+package samplify
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+
+// ExclusionType ...
+type ExclusionType string
+
+var ExclusionTypes = []ExclusionType{
+	ExclusionTypeProject,
+	ExclusionTypeTag,
+	ExclusionTypeThisMonth,
+	ExclusionTypeLastMonth,
+	ExclusionTypeLastThreeMonth,
+	ExclusionTypeCustom,
+}
+
+// ExclusionType values
+const (
+	ExclusionTypeProject 		ExclusionType = "PROJECT"
+	ExclusionTypeTag 			ExclusionType = "TAG"
+	ExclusionTypeThisMonth     	ExclusionType = "THIS_MONTH"
+	ExclusionTypeLastMonth     	ExclusionType = "LAST_MONTH"
+	ExclusionTypeLastThreeMonth ExclusionType = "LAST_THREE_MONTHS"
+	ExclusionTypeCustom     	ExclusionType = "CUSTOM"
+)
+
+func (p ExclusionType) String() string {
+	return string(p)
+}
+
+// Exclusions ... Project's exclusions
+type Exclusions struct {
+	Type ExclusionType `json:"type" valid:"ExclusionType"`
+	List []string      `json:"list"`
+	StartDate *string  `json:"startDate"`
+	EndDate   *string  `json:"endDate"`
+}
+
+func (e Exclusions) Compute() (*string, *string){
+	now := time.Now()
+	current := now.Format(TimeLayout)
+	switch e.Type {
+	case ExclusionTypeThisMonth:
+		startDate := BeginningOfMonth(now).Format(TimeLayout)
+		return &startDate, &current
+	case ExclusionTypeLastMonth:
+		startDate := DaysBeforeAfterMonth(now, -30).Format(TimeLayout)
+		return &startDate, &current
+	case ExclusionTypeLastThreeMonth:
+		startDate := DaysBeforeAfterMonth(now, -90).Format(TimeLayout)
+		return &startDate, &current
+	case ExclusionTypeCustom:
+		return e.StartDate,e.EndDate
+	}
+	return nil, nil
+}
+
+func BeginningOfMonth(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, t.Location())
+}
+func DaysBeforeAfterMonth(t time.Time, days int) time.Time {
+	return t.AddDate(0, 0, days)
+}
+
+func EndOfMonth(t time.Time) time.Time {
+	return BeginningOfMonth(t).AddDate(0, 1, 0).Add(-time.Second)
+}
+
+func (e Exclusions) Validate() error {
+	switch e.Type {
+	case ExclusionTypeCustom:
+		if e.StartDate == nil{
+			return errors.New("exclusion start date cannot be empty")
+		}
+		if e.EndDate == nil {
+			return errors.New("exclusion end date cannot be empty")
+		}
+		start, err := time.Parse(TimeLayout, *e.StartDate)
+		end, err := time.Parse(TimeLayout, *e.EndDate)
+		if err != nil{
+			return err
+		}
+		if start.After(end) || end.Before(start){
+			return fmt.Errorf("invalid date ranges: %s and %s", *e.StartDate, *e.EndDate)
+		}
+	}
+	return nil
+}

--- a/lib/exclusions.go
+++ b/lib/exclusions.go
@@ -87,11 +87,13 @@ func (e *Exclusions) ValidateDates() error {
 			return errors.New("exclusion end date cannot be empty")
 		}
 		start, err := time.Parse(TimeLayout, *e.StartDate)
-		end, err := time.Parse(TimeLayout, *e.EndDate)
-		if err != nil{
+		if err != nil {
 			return err
 		}
-
+		end, err := time.Parse(TimeLayout, *e.EndDate)
+		if err != nil {
+			return err
+		}
 		if start.After(end) || end.Before(start) {
 			return fmt.Errorf("invalid date ranges: %s and %s", *e.StartDate, *e.EndDate)
 		}

--- a/lib/project.go
+++ b/lib/project.go
@@ -1,6 +1,8 @@
 package samplify
 
-import "os"
+import (
+	"os"
+)
 
 // DeviceType ...
 type DeviceType string
@@ -12,13 +14,8 @@ const (
 	DeviceTypeTablet  DeviceType = "tablet"
 )
 
-// ExclusionType ...
-type ExclusionType string
-
-// ExclusionType values
-const (
-	ExclusionTypeProject ExclusionType = "PROJECT"
-	ExclusionTypeTag     ExclusionType = "TAG"
+const(
+	TimeLayout = "2006-01-02"
 )
 
 // State ...
@@ -49,12 +46,6 @@ const (
 // Category is a Project's category
 type Category struct {
 	SurveyTopic []string `json:"surveyTopic" valid:"required"`
-}
-
-// Exclusions ... Project's exclusions
-type Exclusions struct {
-	Type ExclusionType `json:"type" valid:"ExclusionType"`
-	List []string      `json:"list"`
 }
 
 // Author ...

--- a/lib/validate.go
+++ b/lib/validate.go
@@ -130,11 +130,16 @@ func ValidateDeviceType(val DeviceType) error {
 
 // ValidateExclusionType ...
 func ValidateExclusionType(val ExclusionType) error {
-	if val != ExclusionTypeProject &&
+	for _, et := range ExclusionTypes{
+		if val == et {
+			return nil
+		}
+	}
+	/*if val != ExclusionTypeProject &&
 		val != ExclusionTypeTag {
 		return ErrInvalidFieldValue
-	}
-	return nil
+	}*/
+	return ErrInvalidFieldValue
 }
 
 // ValidateQuotaPlan ...

--- a/lib/validate.go
+++ b/lib/validate.go
@@ -135,10 +135,6 @@ func ValidateExclusionType(val ExclusionType) error {
 			return nil
 		}
 	}
-	/*if val != ExclusionTypeProject &&
-		val != ExclusionTypeTag {
-		return ErrInvalidFieldValue
-	}*/
 	return ErrInvalidFieldValue
 }
 


### PR DESCRIPTION
Due to Samplify Backend uses all of these structs from the API, i extends the Project Exclusions with the necessary fields. All of the previous exclusions available (PROJECT,TAG), the dates are optional, so it is backward compatible.