### PR TITLE
adding standard Go .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,18 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# IDE files
 .idea


### PR DESCRIPTION
adding standard Go .gitignore from https://github.com/github/gitignore/blob/master/Go.gitignore