### PR TITLE
Rebase from source

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,40 @@
+name: Go
+
+on:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - v*
+    paths-ignore:
+      - VERSION
+      - CHANGELOG.md
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+
+      - name: Test
+        env:
+          CGO_ENABLED: '0'
+          GO111MODULE: 'on'
+        run: |
+          go test -cover -covermode=count -coverprofile=coverage.out ./...
+          go tool cover -func=coverage.out

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,11 @@
-module github.com/researchnow/go-samplifyapi-client
+module github.com/morningconsult/go-samplifyapi-client
 
-go 1.13
+go 1.15
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
-	github.com/corpix/uarand v0.1.1 // indirect
-	github.com/etgryphon/stringUp v0.0.0-20121020160746-31534ccd8cac // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0
-	github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428 // indirect
 	github.com/leebenson/conform v0.0.0-20190822094432-4c55492f71d7
+	github.com/researchnow/go-samplifyapi-client v0.0.0-20210804183500-577717f0c08a
 	github.com/researchnow/tareekh v0.0.0-20200818130035-8cc1b656a124
-	github.com/stretchr/testify v1.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,11 @@ go 1.15
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+	github.com/corpix/uarand v0.1.1 // indirect
+	github.com/etgryphon/stringUp v0.0.0-20121020160746-31534ccd8cac // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0
+	github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428 // indirect
 	github.com/leebenson/conform v0.0.0-20190822094432-4c55492f71d7
-	github.com/researchnow/go-samplifyapi-client v0.0.0-20210804183500-577717f0c08a
 	github.com/researchnow/tareekh v0.0.0-20200818130035-8cc1b656a124
+	github.com/stretchr/testify v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,6 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/ngdinhtoan/glide-cleanup v0.2.0/go.mod h1:UQzsmiDOb8YV3nOsCxK/c9zPpCZVNoHScRE3EO9pVMM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/researchnow/go-samplifyapi-client v0.0.0-20210804183500-577717f0c08a h1:aXRVEXx4YX28kEkn/CwRY+YKwGJFXdHi8SDIB6loCZ0=
-github.com/researchnow/go-samplifyapi-client v0.0.0-20210804183500-577717f0c08a/go.mod h1:JgqEsme1RW7PGfTDeqJHyErIu9dCxE24cEi3CJ5SBEQ=
 github.com/researchnow/tareekh v0.0.0-20200818130035-8cc1b656a124 h1:eTHTFsCxFWSxRvDADNGPWKQmxdFzhl+TRJ872uvXJgs=
 github.com/researchnow/tareekh v0.0.0-20200818130035-8cc1b656a124/go.mod h1:kld4GKAdBsg7YmAKwEz6cLXpl0kr6vv7v2kM9tdGAmE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/ngdinhtoan/glide-cleanup v0.2.0/go.mod h1:UQzsmiDOb8YV3nOsCxK/c9zPpCZVNoHScRE3EO9pVMM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/researchnow/go-samplifyapi-client v0.0.0-20210804183500-577717f0c08a h1:aXRVEXx4YX28kEkn/CwRY+YKwGJFXdHi8SDIB6loCZ0=
+github.com/researchnow/go-samplifyapi-client v0.0.0-20210804183500-577717f0c08a/go.mod h1:JgqEsme1RW7PGfTDeqJHyErIu9dCxE24cEi3CJ5SBEQ=
 github.com/researchnow/tareekh v0.0.0-20200818130035-8cc1b656a124 h1:eTHTFsCxFWSxRvDADNGPWKQmxdFzhl+TRJ872uvXJgs=
 github.com/researchnow/tareekh v0.0.0-20200818130035-8cc1b656a124/go.mod h1:kld4GKAdBsg7YmAKwEz6cLXpl0kr6vv7v2kM9tdGAmE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/lib/client.go
+++ b/lib/client.go
@@ -169,7 +169,6 @@ func (c *Client) CreateProject(project *CreateProjectCriteria) (*ProjectResponse
 
 // UpdateProjectWithContext ...
 func (c *Client) UpdateProjectWithContext(ctx context.Context, project *UpdateProjectCriteria) (*ProjectResponse, error) {
-
 	err := Validate(project)
 	if err != nil {
 		return nil, err

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -268,7 +268,6 @@ func getLineItemCriteria() *samplify.CreateLineItemCriteria {
 		IndicativeIncidence: 20.0,
 		DaysInField:         20,
 		LengthOfInterview:   10,
-		RequiredCompletes:   200,
 		SurveyTestingNotes:  &surveyTestingNotesVal,
 		QuotaPlan: &samplify.QuotaPlan{
 			Filters: []*samplify.QuotaFilters{

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	samplify "github.com/researchnow/go-samplifyapi-client/lib"
+	samplify "github.com/morningconsult/go-samplifyapi-client/lib"
 )
 
 func TestAuth(t *testing.T) {

--- a/lib/line_item.go
+++ b/lib/line_item.go
@@ -131,7 +131,6 @@ type LineItem struct {
 	FieldSchedule       *Schedule         `json:"fieldSchedule"`
 	LengthOfInterview   int64             `json:"lengthOfInterview"`
 	DeliveryType        *string           `json:"deliveryType"`
-	RequiredCompletes   int64             `json:"requiredCompletes"`
 	QuotaPlan           *QuotaPlan        `json:"quotaPlan"`
 	EndLinks            *EndLinks         `json:"endLinks"`
 	SurveyURLParams     []*URLParameter   `json:"surveyURLParams"`
@@ -187,7 +186,6 @@ type CreateLineItemCriteria struct {
 	FieldSchedule       *Schedule         `json:"fieldSchedule" valid:"optional"`
 	LengthOfInterview   int64             `json:"lengthOfInterview" valid:"required"`
 	DeliveryType        *string           `json:"deliveryType" valid:"optional"`
-	RequiredCompletes   int64             `json:"requiredCompletes" valid:"required"`
 	QuotaPlan           *QuotaPlan        `json:"quotaPlan,omitempty" valid:"optional,quotaPlan"`
 	SurveyURLParams     []*URLParameter   `json:"surveyURLParams" valid:"optional"`
 	SurveyTestURLParams []*URLParameter   `json:"surveyTestURLParams" valid:"optional"`
@@ -209,7 +207,6 @@ type UpdateLineItemCriteria struct {
 	FieldSchedule       *Schedule          `json:"fieldSchedule" valid:"optional"`
 	LengthOfInterview   *int64             `json:"lengthOfInterview,omitempty" valid:"optional"`
 	DeliveryType        *string            `json:"deliveryType" valid:"optional"`
-	RequiredCompletes   *int64             `json:"requiredCompletes,omitempty" valid:"optional"`
 	QuotaPlan           *QuotaPlan         `json:"quotaPlan,omitempty" valid:"optional,quotaPlan"`
 	SurveyURLParams     []*URLParameter    `json:"surveyURLParams" valid:"optional"`
 	SurveyTestURLParams []*URLParameter    `json:"surveyTestURLParams" valid:"optional"`

--- a/lib/query_test.go
+++ b/lib/query_test.go
@@ -3,7 +3,7 @@ package samplify_test
 import (
 	"testing"
 
-	samplify "github.com/researchnow/go-samplifyapi-client/lib"
+	samplify "github.com/morningconsult/go-samplifyapi-client/lib"
 )
 
 func TestInSliceString(t *testing.T) {

--- a/lib/request.go
+++ b/lib/request.go
@@ -10,8 +10,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"time"
-
-	"github.com/hashicorp/go-retryablehttp"
 )
 
 // APIResponse ...
@@ -22,8 +20,8 @@ type APIResponse struct {
 
 // SendRequestWithContext exposing sendrequest to enable custom requests
 func SendRequestWithContext(ctx context.Context, host, method, url, accessToken string, body interface{}, timeout int) (*APIResponse, error) {
-	opt := &extraOptions{}
-	return sendRequest(ctx, host, method, url, accessToken, body, timeout, false, opt)
+	c := NewClient("", "", "", &ClientOptions{Timeout: &timeout})
+	return c.sendRequest(ctx, host, method, url, accessToken, body)
 }
 
 // SendRequest exposing sendrequest to enable custom requests
@@ -31,13 +29,12 @@ func SendRequest(host, method, url, accessToken string, body interface{}, timeou
 	return SendRequestWithContext(context.Background(), host, method, url, accessToken, body, timeout)
 }
 
-func sendRequest(ctx context.Context, host, method, url, accessToken string, body interface{}, timeout int, disableRetry bool, opt *extraOptions) (*APIResponse, error) {
+func (c *Client) sendRequest(ctx context.Context, host, method, url, accessToken string, body interface{}) (*APIResponse, error) {
 	// log.WithFields(log.Fields{"module": "go-samplifyapi-client", "function": "sendRequest", "URL": fmt.Sprintf("%s%s", host, url), "Method": method}).Info()
 	jstr, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
-
 	req, err := http.NewRequest(method, fmt.Sprintf("%s%s", host, url), bytes.NewBuffer(jstr))
 	if err != nil {
 		return nil, err
@@ -48,29 +45,11 @@ func sendRequest(ctx context.Context, host, method, url, accessToken string, bod
 	if len(accessToken) > 0 {
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 	}
-
-	var resp *http.Response
-	if !disableRetry && opt != nil && opt.retryEnabled {
-
-		retryableClient := retryablehttp.NewClient()
-
-		dur := time.Duration(timeout)
-		retryableClient.HTTPClient.Timeout = time.Second * dur
-
-		retryableClient.RetryMax = opt.maxRetries
-		retryableClient.ErrorHandler = retryablehttp.PassthroughErrorHandler
-
-		resp, err = retryableClient.StandardClient().Do(req)
-	} else {
-		dur := time.Duration(timeout)
-		client := &http.Client{
-			Timeout: time.Second * dur,
-		}
-		resp, err = client.Do(req)
-	}
+	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	bodyjson, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -100,12 +79,8 @@ func sendRequest(ctx context.Context, host, method, url, accessToken string, bod
 	return ar, err
 }
 
-func sendFormData(ctx context.Context, host, method, path, accessToken string, file multipart.File, fileName string, message string, timeout int) (*APIResponse, error) {
+func (c *Client) sendFormData(ctx context.Context, host, method, path, accessToken string, file multipart.File, fileName string, message string) (*APIResponse, error) {
 	// log.WithFields(log.Fields{"module": "go-samplifyapi-client", "function": "sendFormData", "URL": fmt.Sprintf("%s%s", host, path), "Method": method}).Info()
-	dur := time.Duration(timeout)
-	client := &http.Client{
-		Timeout: time.Second * dur,
-	}
 	bodyBuf := &bytes.Buffer{}
 	bodyWriter := multipart.NewWriter(bodyBuf)
 	fileWriter, err := bodyWriter.CreateFormFile("file", fileName)
@@ -128,10 +103,11 @@ func sendFormData(ctx context.Context, host, method, path, accessToken string, f
 	}
 	req.Header.Add("Content-Type", bodyWriter.FormDataContentType())
 	req = req.WithContext(ctx)
-	resp, err := client.Do(req)
+	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	bodyjson, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/lib/url/format_test.go
+++ b/lib/url/format_test.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"testing"
 
-	formatURL "github.com/researchnow/go-samplifyapi-client/lib/url"
+	formatURL "github.com/morningconsult/go-samplifyapi-client/lib/url"
 )
 
 func TestFormat(t *testing.T) {

--- a/lib/validate_test.go
+++ b/lib/validate_test.go
@@ -2,8 +2,9 @@ package samplify_test
 
 import (
 	"encoding/json"
-	samplify "github.com/researchnow/go-samplifyapi-client/lib"
 	"testing"
+
+	samplify "github.com/morningconsult/go-samplifyapi-client/lib"
 )
 
 func TestValidateSurveyLink(t *testing.T) {


### PR DESCRIPTION
Rebase our forked repository from the source ([https://github.com/morningconsult/go-samplifyapi-client](https://github.com/morningconsult/go-samplifyapi-client)).

The source repo appears to have added some extra options for configuring retry behavior when making HTTP requests. I chose to omit these new options because they can be configured directly via the HTTP client.